### PR TITLE
isisd: Cleanup compile issue

### DIFF
--- a/isisd/isis_dlpi.c
+++ b/isisd/isis_dlpi.c
@@ -469,7 +469,7 @@ int isis_sock_init(struct isis_circuit *circuit)
 	int retval = ISIS_OK;
 
 	if (isisd_privs.change(ZPRIVS_RAISE))
-		zlog_ferr(LIB_ERR_PRIVILEGE, "%s: could not raise privs, %s",
+		zlog_ferr(LIB_ERR_PRIVILEGES, "%s: could not raise privs, %s",
 			  __func__, safe_strerror(errno));
 
 	retval = open_dlpi_dev(circuit);
@@ -490,7 +490,7 @@ int isis_sock_init(struct isis_circuit *circuit)
 
 end:
 	if (isisd_privs.change(ZPRIVS_LOWER))
-		zlog_ferr(LIB_ERR_PRIVILEGE, "%s: could not lower privs, %s",
+		zlog_ferr(LIB_ERR_PRIVILEGES, "%s: could not lower privs, %s",
 			  __func__, safe_strerror(errno));
 
 	return retval;


### PR DESCRIPTION
cleanup compile with missnamed enum usage.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>